### PR TITLE
Fix bug in "next" schedule calculation

### DIFF
--- a/lib/models/tasksystem/task_host.dart
+++ b/lib/models/tasksystem/task_host.dart
@@ -259,10 +259,10 @@ class TaskHost {
           dayOffset -= dayOfWeek;
           return searchDate.add(Duration(days: dayOffset));
         }
-        dayOffset++;
-        if (dayOffset > 6) {
-          dayOffset = 0;
-        }
+      }
+      dayOffset++;
+      if (dayOffset > 6) {
+        dayOffset = 0;
       }
     } while (dayOffset != dayOfWeek);
 


### PR DESCRIPTION
Sometimes the calculation will fail, returning a date completely different from what was expected. This PR fixes that issue