### PR TITLE
Shortened dragging interval

### DIFF
--- a/lib/ui/main_page.dart
+++ b/lib/ui/main_page.dart
@@ -197,7 +197,7 @@ class _MainPageState extends State<MainPage> {
     var listTile = _buildTaskWidget(task, compact);
     return onMobile && !onTablet
         ? listTile
-        : LongPressDraggable(
+        : Draggable(
             data: task,
             dragAnchorStrategy: pointerDragAnchorStrategy,
             feedback: task.GetIcon(),


### PR DESCRIPTION
Current dragging interval is long on desktop due do it being a LongPressDraggable, which makes sense in a mobile context, but slows things down on desktop. Shortens the interval by replacing it with a Draggable only on desktop